### PR TITLE
Upgraded org.jmdns/jmdns and others.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,9 @@
   :url "https://github.com/cassiel/clojure-zeroconf"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[javax.jmdns/jmdns "3.4.1"]
-                 [org.clojure/clojure "1.5.1"]]
-  :plugins [[lein-marginalia "0.7.1"]])
+  :dependencies [[org.slf4j/slf4j-api "1.7.18"]
+                 [org.slf4j/slf4j-simple "1.7.18"]
+                 [org.jmdns/jmdns "3.5.0"]
+                 [org.clojure/clojure "1.6.0"]]
+  :repositories {"bintray" "https://dl.bintray.com/jmdns/mvn/"}
+  :plugins [[lein-marginalia "0.8.0"]])


### PR DESCRIPTION
`org.jmdns/jmdns` now lives here: https://github.com/jmdns/jmdns  ([Maven](https://bintray.com/jmdns/mvn/jmdns/view))
As of 3.5.0 they rely on `slf4j-simple` and require it as an external dependency. 

I upgraded Clojure to 1.6 in order to take advantage of the changes but also remain compatible with older projects. 

Though Clojure 1.7.0 and 1.8.0 were tested and work fine.

I am not sure if adding the bintray repository is optimal, but that is where their maven repository lives. I couldn't find the latest version on Central or Clojars. 

Tested by running the example in the readme, no errors or warnings.
